### PR TITLE
Retrofit fallback data to users that don't have it, etc.

### DIFF
--- a/src/main/java/org/lantern/SendInviteTask.java
+++ b/src/main/java/org/lantern/SendInviteTask.java
@@ -1,0 +1,46 @@
+package org.lantern;
+
+import java.util.logging.Logger;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.lantern.data.Dao;
+import org.lantern.data.Invite;
+
+
+@SuppressWarnings("serial")
+public class SendInviteTask extends HttpServlet {
+
+    private static final transient Logger log = Logger
+            .getLogger(SendInviteTask.class.getName());
+
+    @Override
+    public void doPost(final HttpServletRequest request,
+                       final HttpServletResponse response) {
+        String inviterEmail = request.getParameter("inviterEmail");
+        String inviteeEmail = request.getParameter("inviteeEmail");
+        String description = "invite email from " + inviterEmail
+                              + " to " + inviteeEmail;
+        log.info("Sending " + description);
+        String inviterName = request.getParameter("inviterName");
+        if ("null".equals(inviterName)) {
+            inviterName = null;
+        }
+        if (FallbackProxyLauncher.sendInviteEmail(
+                inviterName,
+                inviterEmail,
+                inviteeEmail,
+                request.getParameter("installerLocation"),
+                request.getParameter("inviteeEverSignedIn").equals("true"))) {
+            new Dao().setInviteStatus(inviterEmail,
+                                      inviteeEmail,
+                                      Invite.Status.sent);
+            LanternControllerUtils.populateOKResponse(response, "OK");
+            log.info("Invite task reported success.");
+        } else {
+            throw new RuntimeException("Couldn't send " + description + "!");
+        }
+    }
+}

--- a/src/main/java/org/lantern/data/Dao.java
+++ b/src/main/java/org/lantern/data/Dao.java
@@ -320,11 +320,12 @@ public class Dao extends DAOBase {
     }
 
     /**
-     * Update fallbackProxyUserId if we got a non-default
+     * Update fallbackProxyUserId and fallbackProxy if we got a non-default
      * fallbackProxyHostAndPort.
      */
     public void processFallbackProxyHostAndPort(final String userId,
                                                 final String hostAndPort) {
+        log.info("Processing host:port for " + userId);
         if (StringUtils.isBlank(hostAndPort)) {
             log.info("No hostAndPort.");
             return;
@@ -341,13 +342,6 @@ public class Dao extends DAOBase {
             @Override
             protected Boolean run(Objectify txnOfy) {
                 LanternUser user = txnOfy.find(LanternUser.class, userId);
-
-                if (userId.equals(user.getFallbackProxyUserId())) {
-                    // Once we know a user has a fallback proxy running as them,
-                    // that takes precedence over what proxy are they using.
-                    log.info("User is its own proxy; we never override that.");
-                    return false;
-                }
 
                 // The only point of the transaction is to protect the read
                 // and write of the user entry, and to make sure that we only
@@ -381,20 +375,34 @@ public class Dao extends DAOBase {
                     return false;
                 }
 
-                String oldId = user.getFallbackProxyUserId();
-                String newId = instance.getUser();
-
-                if (newId.equals(oldId)) {
-                    log.info("fallbackProxyUserId unchanged.");
-                    return false;
+                String oldFpuid = user.getFallbackProxyUserId();
+                String newFpuid = instance.getUser();
+                boolean fpUserChanged = !newFpuid.equals(oldFpuid)
+                                        // If a user is their own fallback
+                                        // user, we don't override that.
+                                        && !userId.equals(oldFpuid);
+                if (fpUserChanged) {
+                    user.setFallbackProxyUserId(newFpuid);
+                    log.info("Set " + userId + "'s fallbackProxyUserId to "
+                             + newFpuid + " (was " + oldFpuid + ")");
                 }
 
-                user.setFallbackProxyUserId(newId);
-                txnOfy.put(user);
-                txnOfy.getTxn().commit();
-                log.info("Set " + userId + "'s fallbackProxyUserId to "
-                         + newId + " (was " + oldId + ")");
-                return oldId == null;
+                Key<LanternInstance> oldFpKey = user.getFallbackProxy();
+                Key<LanternInstance> newFpKey
+                    = getInstanceKey(newFpuid, instance.getId());
+                boolean fpChanged = !newFpKey.equals(oldFpKey);
+                if (fpChanged) {
+                    user.setFallbackProxy(newFpKey);
+                    log.info("Set " + userId + "'s fallbackProxy to "
+                             + newFpKey + " (was " + oldFpKey + ")");
+                }
+
+                if (fpUserChanged || fpChanged) {
+                    txnOfy.put(user);
+                    txnOfy.getTxn().commit();
+                }
+
+                return fpUserChanged;
             }
         }.run();
 
@@ -414,6 +422,7 @@ public class Dao extends DAOBase {
      * Invites or users without fallbackProxyUserId.
      */
     private void updateInvitesToFallbackBalancingScheme(final String userId) {
+        log.info("Updating " + userId + "'s invites.");
         Objectify ofy = ofy();
         Key<LanternUser> userKey = new Key<LanternUser>(
                                         LanternUser.class, userId);
@@ -426,22 +435,24 @@ public class Dao extends DAOBase {
             return;
         }
         List<Invite> invites = ofy.query(Invite.class)
-                                  .ancestor(userKey)
+                                  .filter("inviter", userId)
                                   .list();
+        log.info("Got " + invites.size() + " invites from " + userId
+                 + " to update.");
         for (Invite invite : invites) {
             ofy.delete(invite);
             Invite newInvite = new Invite(userId,
                                           invite.getInvitee(),
                                           fpuid);
             newInvite.setStatus(invite.getStatus());
-            newInvite.setLastAttempt(invite.getLastAttempt());
             ofy.put(newInvite);
         }
 
         for (Invite invite : invites) {
             if (invite.getStatus() == Invite.Status.authorized) {
-                FallbackProxyLauncher.authorizeInvite(userId,
-                                                      invite.getInvitee());
+                log.info("Thawing invite to " + invite.getInvitee());
+                FallbackProxyLauncher.processAuthorizedInvite(
+                        userId, invite.getInvitee());
             }
         }
     }
@@ -604,75 +615,41 @@ public class Dao extends DAOBase {
         }
     }
 
-    /**
-     * This method prepares to send the invite identified by the given inviteId.
-     * Depending on various checks, the invite may or may not actually need to
-     * be sent.  If it doesn't need to be sent, this method returns null.
-     * .
-     * 
-     * @param inviteId
-     * @return the inviter from which to send (or null if it shouldn't be sent)
-     */
-    public LanternUser prepareToSendInvite(final String inviterEmail, final String inviteeEmail) {
-        boolean shouldSend = new RetryingTransaction<Boolean>() {
-            @Override
-            public Boolean run(Objectify ofy) {
-                final Invite invite = getInvite(ofy, inviterEmail, inviteeEmail);
-                boolean shouldSend = invite.shouldSend();
-                if (shouldSend) {
-                    invite.setStatus(Status.sending);
-                    invite.setLastAttempt(System.currentTimeMillis());
-                    ofy.put(invite);
-
-                    final LanternUser inviter = ofy.find(LanternUser.class,
-                            invite.getInviter());
-                    if (inviter == null) {
-                        log.severe("Finalizing invites of nonexistent user?");
-                        shouldSend = false;
-                    } else {
-                        ofy.getTxn().commit();
-                        log.info("Transaction successful.");
-                    }
-                }
-                
-                return shouldSend;
-            }
-        }.run();
-
-        LanternUser inviter = createInviteeUser(inviterEmail, inviteeEmail);
-        return shouldSend ? inviter : null;
-    }
-
-    private LanternUser createInviteeUser(final String inviterEmail,
-            final String inviteeEmail) {
-
-        // get the inviter outside the loop because we don't care
-        // about concurrent modifications
+    public LanternUser createInvitee(final LanternUser inviter,
+                                     final String inviteeEmail,
+                                     final String fallbackProxyUserId,
+                                     final String fallbackInstanceId) {
         final Objectify ofy = ofy();
-        final LanternUser inviter = ofy.find(LanternUser.class, inviterEmail);
-
-        new RetryingTransaction<Void>() {
+        RetryingTransaction<LanternUser> txn
+            = new RetryingTransaction<LanternUser>() {
             @Override
-            public Void run(Objectify ofy) {
-                LanternUser invitee = ofy.find(LanternUser.class, inviteeEmail);
+            public LanternUser run(Objectify ofy) {
+                LanternUser invitee = ofy.find(LanternUser.class,
+                                               inviteeEmail);
                 if (invitee == null) {
                     log.info("Adding invitee to database");
                     invitee = new LanternUser(inviteeEmail);
-
                     invitee.setDegree(inviter.getDegree() + 1);
                     invitee.setSponsor(inviter.getId());
+                    invitee.setFallbackProxyUserId(fallbackProxyUserId);
+                    invitee.setFallbackProxy(
+                            getInstanceKey(fallbackProxyUserId,
+                                           fallbackInstanceId));
                     ofy.put(invitee);
                     ofy.getTxn().commit();
                     log.info("Successfully committed attempt to add invitee.");
                 } else {
                     log.info("Invitee exists, nothing to do here.");
                 }
-                
-                return null;
+                return invitee;
             }
-        }.run();
-
-        return inviter;
+        };
+        LanternUser invitee = txn.run();
+        if (txn.failed()) {
+            throw new RuntimeException(
+                    "Transaction failed trying to create " + inviteeEmail);
+        }
+        return invitee;
     }
 
     public boolean alreadyInvitedBy(Objectify ofy, final String inviterEmail,
@@ -1520,5 +1497,66 @@ public class Dao extends DAOBase {
         log.info("Incremented " + userId + "'s fallbackSerialNumber to "
                  + ret);
         return ret;
+    }
+
+    // Transitional.
+    public List<Integer> XXXRetrofitFallbackProxyUsers() {
+        Objectify ofy = ofy();
+        Query<LanternUser> users = ofy.query(LanternUser.class);
+        int newlyUpdated = 0;
+        int notReady = 0;
+        int alreadyUpToDate = 0;
+        for (LanternUser user : users) {
+            if (user.getFallbackProxy() == null) {
+                if (XXXRetrofitFallbackProxyUser(user.getId())) {
+                    newlyUpdated += 1;
+                    updateInvitesToFallbackBalancingScheme(user.getId());
+                } else {
+                    notReady += 1;
+                }
+            } else {
+                alreadyUpToDate += 1;
+            }
+        }
+        List<Integer> ret = new ArrayList<Integer>();
+        ret.add(alreadyUpToDate);
+        ret.add(notReady);
+        ret.add(newlyUpdated);
+        return ret;
+    }
+
+    private boolean XXXRetrofitFallbackProxyUser(final String userId) {
+        RetryingTransaction<Boolean> txn = new RetryingTransaction<Boolean>() {
+            protected Boolean run(Objectify ofy) {
+                LanternUser user = ofy.find(LanternUser.class, userId);
+                String fpUserId = user.getFallbackProxyUserId();
+                if (fpUserId == null) {
+                    // Use a different ofy here because the sponsor is not in
+                    // the same ancestor group.
+                    LanternUser sponsor = ofy.find(LanternUser.class,
+                                                   user.getSponsor());
+                    fpUserId = sponsor.getFallbackProxyUserId();
+                    if (fpUserId == null) {
+                        return false;
+                    } else {
+                        user.setFallbackProxyUserId(fpUserId);
+                    }
+                }
+                String fpInstanceId = ofy.find(LanternUser.class, fpUserId)
+                                         .getFallbackForNewInvitees();
+                if (fpInstanceId == null) {
+                    return false;
+                }
+                user.setFallbackProxy(getInstanceKey(fpUserId, fpInstanceId));
+                ofy.put(user);
+                ofy.getTxn().commit();
+                return true;
+            }
+        };
+        Boolean result = txn.run();
+        if (txn.failed()) {
+            throw new RuntimeException("Transaction failed!");
+        }
+        return result;
     }
 }

--- a/src/main/java/org/lantern/data/Invite.java
+++ b/src/main/java/org/lantern/data/Invite.java
@@ -56,8 +56,6 @@ public class Invite {
     @Persistent
     private Status status = Status.queued;
 
-    private long lastAttempt;
-
     public Invite() {
     };
 
@@ -76,21 +74,6 @@ public class Invite {
         return id.split("\1");
     }
 
-    public boolean shouldSend() {
-        switch (status) {
-        case queued:
-            return false;
-        case authorized:
-            return true;
-        case sent:
-            return false;
-        case sending:
-            long now = System.currentTimeMillis();
-            return now - lastAttempt > 60 * 1000;
-        }
-        return false;
-    }
-    
     public String getId() {
         return id;
     }
@@ -110,13 +93,4 @@ public class Invite {
     public void setStatus(Status status) {
         this.status = status;
     }
-
-    public long getLastAttempt() {
-        return lastAttempt;
-    }
-
-    public void setLastAttempt(long lastAttempt) {
-        this.lastAttempt = lastAttempt;
-    }
-
 }

--- a/src/main/java/org/lantern/data/LanternUser.java
+++ b/src/main/java/org/lantern/data/LanternUser.java
@@ -66,6 +66,14 @@ public class LanternUser implements Serializable {
     private String fallbackProxyUserId;
 
     /**
+     * The fallback proxy we believe this user is using.
+     *
+     * A user may actually be using different fallback proxies from different
+     * installations of Lantern, but any of them is good for our purposes.
+     */
+    private Key<LanternInstance> fallbackProxy;
+
+    /**
      * instanceId of the fallback proxy to use for new invitees.
      *
      * null if we have never launched a fallback proxy to run as this user.
@@ -256,5 +264,13 @@ public class LanternUser implements Serializable {
     public int incrementFallbackSerialNumber() {
         fallbackSerialNumber += 1;
         return fallbackSerialNumber;
+    }
+
+    public Key<LanternInstance> getFallbackProxy() {
+        return fallbackProxy;
+    }
+
+    public void setFallbackProxy(Key<LanternInstance> fallbackProxy) {
+        this.fallbackProxy = fallbackProxy;
     }
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -76,6 +76,16 @@
   </servlet-mapping>
   
   <servlet>
+    <servlet-name>sendInviteTask</servlet-name>
+    <servlet-class>org.lantern.SendInviteTask</servlet-class>
+  </servlet>
+
+  <servlet-mapping>
+    <servlet-name>sendInviteTask</servlet-name>
+    <url-pattern>/send_invite_task</url-pattern>
+  </servlet-mapping>
+
+  <servlet>
     <servlet-name>subscribed</servlet-name>
     <servlet-class>org.lantern.XmppSubscribedServlet</servlet-class>
   </servlet>
@@ -142,6 +152,7 @@
       <url-pattern>/persist/*</url-pattern>
       <url-pattern>/check_sqs</url-pattern>
       <url-pattern>/admin/*</url-pattern>
+      <url-pattern>/send_invite_task</url-pattern>
     </web-resource-collection>
     <auth-constraint>
       <role-name>admin</role-name>

--- a/src/test/java/org/lantern/RemoteApi.java
+++ b/src/test/java/org/lantern/RemoteApi.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.io.IOUtils;
@@ -52,6 +53,10 @@ public class RemoteApi {
 
         try {
             final Dao dao = new Dao();
+            List<Integer> ret = dao.XXXRetrofitFallbackProxyUsers();
+            System.out.println("Already up to date: " + ret.get(0));
+            System.out.println("Not ready to update: " + ret.get(1));
+            System.out.println("Newly updated: " + ret.get(2));
             //dao.forgetEveryoneSignedIn();
             /* Trigger your hacks here.*/
             //dao.createInitialUser("insertmyaccount@getlantern.org");


### PR DESCRIPTION
Fallback data comprises fallbackProxyUserId and newly created field
fallbackProxy.  The latter will be used to get the installerLocation
for update emails.

Also initialize this data on user creation.

Since it was simpler to do the refactoring than to dig deeper in the
hole of the shouldSendInvite/prepareForSending scheme, which was not
really working anyway (we had no way to retry sending invites), I
moved the actual sending of invites to a TaskQueue task.

Tests performed prior to committing this:

```
Check that invite e-mails get sent at all with the TaskQueued flow. OK
Check that a newly invited user gets the fallbackProxyUserId and fallbackProxy set. OK
Check that fallbackProxyUserId and fallbackProxy get overridden on XMPP Available presences. OK
    But for fallback users, only the fallbackProxy. OK
    Check that authorized invites that were held because of lack of fallbackProxyUserId get sent as a result of this. OK
Check that fallbackProxyUserId and fallbackProxy get initialized (but not overriden) when running the update job. OK
    Same caveats as above. OK
```
