### PR TITLE
Add a small random delay when retrying transactions.

### DIFF
--- a/src/main/java/org/lantern/data/RetryingTransaction.java
+++ b/src/main/java/org/lantern/data/RetryingTransaction.java
@@ -2,6 +2,7 @@ package org.lantern.data;
 
 import java.util.ConcurrentModificationException;
 import java.util.logging.Logger;
+import java.util.Random;
 
 import com.googlecode.objectify.Objectify;
 import com.googlecode.objectify.ObjectifyService;
@@ -25,6 +26,9 @@ public abstract class RetryingTransaction<T> {
                 return result;
             } catch (final ConcurrentModificationException e) {
                 log.info("Concurrent modification! Retrying...");
+                try {
+                    Thread.sleep(500 + new Random().nextInt(1000));
+                } catch (InterruptedException ex) {}
                 continue;
             } finally {
                 if (ofy.getTxn().isActive()) {


### PR DESCRIPTION
When a transaction fails because of a ConcurrentModificationException, retrying ASAP doesn't sound like the most reasonable thing to do.  The proposed change adds a delay between half a second and a second and a half, so hopefully at some point one of the concurrent guys will have time to do its thing.  The numbers were chosen to be well within GAE timeout times, leaving some time for the task's own work (we retry up to 10 times, so this adds a 15 second delay at the most.)  They are a first guess, though, and I'm open to suggestions.
